### PR TITLE
#4 Refactor tiny emitter

### DIFF
--- a/src/tinyemmiter.js
+++ b/src/tinyemmiter.js
@@ -2,39 +2,93 @@
 // Based on:
 // https://github.com/scottcorgan/tiny-emitter
 // class based
+
+const isEventValid = (event) => {
+  return event;
+};
+
+const getOrCreateEventSubscribersFor = (allEventSubscribers, event) => 
+  getEventSubscribersFor(event) ? getEventSubscribersFor(event) : createEventSubscribersFor(event);
+
+const getEventSubscribersFor = (allEventSubscribers, event) => allEventSubscribers[event];
+
+const createEventSubscribersFor = (allEventSubscribers, event) => (allEventSubscribers[event] = []);
+
+const subscribeCallback = (eventSubscribers, callback, context, unsubscribeAfterCalled) => {
+  callback.context = context;
+  if (unsubscribeAfterCalled) {
+    callback.off_event = true;
+  }
+  eventSubscribers.push(callback);
+};
+
+const unsubscribeCallback = (allEventSubscribers, event, callbackToRemove) => {
+  if (!callbackToRemove) {
+    delete allEventSubscribers[event];
+  } else {
+    allEventSubscribers[event] = allEventSubscribers[event].filter((callback) => callback !== callbackToRemove);
+  }
+};
+
+const signalSubscribers = (eventSubscribers, ...args) => {
+  const callbacksToUnsubscribeAfterCalled = [];
+  eventSubscribers.each((callback) => {
+    callback.apply(callback.context, [...args]);
+    if (callback.off_event) {
+      callbacksToUnsubscribeAfterCalled.push(callback);
+    }
+  });
+  return callbacksToUnsubscribeAfterCalled;
+};
+
+
 export class Emitter {
+
   emit(event, ...args) {
-    if (!event) return this;
-    for (const fn of this._e(event)) {
-      fn.apply(fn.ctx, [...args]);
-      if (fn.off_event == true) this.off(event, fn);
+    const allEventSubscribers = this;
+    if (isEventValid(event)) {
+      const eventSubscribers = getEventSubscribersFor(event);
+      if (eventSubscribers) {
+        const callbacksToUnsubscribe = signalSubscribers(eventSubscribers, [...args]);
+        callbacksToUnsubscribe.each((callback) => {
+          unsubscribeCallback(allEventSubscribers, event, callback);
+        });
+      }
     }
     return this;
   }
-  on(event, fn, ctx) {
-    if (!event) return this;
-    fn.ctx = ctx;
-    this._e(event).push(fn);
-    return this;
-  }
-  once(event, fn, ctx) {
-    if (!event) return this;
-    fn.ctx = ctx;
-    fn.off_event = true;
-    return this.on(event, fn);
-  }
-  off(event, fn) {
-    if (!event) return this;
-    if (!this[event]) return this;
-    const e = this._e(event);
-    if (!fn) {
-      delete this[event];
-      return this;
+
+  on(event, callback, context) {
+    const allEventSubscribers = this;
+    if (isEventValid(event)) {
+      const eventSubscribers = getOrCreateEventSubscribersFor(allEventSubscribers, event);
+      subscribeCallback(eventSubscribers, callback, context);
     }
-    this[event] = e.filter((f) => f != fn);
     return this;
   }
+
+  once(event, callback, context) {
+    const allEventSubscribers = this;
+    const unsubscribeAfterCalled = true;
+    if (isEventValid(event)) {
+      const eventSubscribers = getOrCreateEventSubscribersFor(allEventSubscribers, event);
+      subscribeCallback(eventSubscribers, callback, context, unsubscribeAfterCalled);
+    }
+    return this;
+  }
+
+  off(event, callback) {
+    const allEventSubscribers = this;
+    if (isEventValid(event)) {
+      const eventSubscribers = getEventSubscribersFor(event);
+      if (eventSubscribers) {
+        unsubscribeCallback(allEventSubscribers, event, callback);
+      }
+    }
+    return this;
+  }
+
   _e(e) {
-    return this[e] || (this[e] = []);
+    return getOrCreateEventSubscribersFor(e);
   }
 }

--- a/src/tinyemmiter.js
+++ b/src/tinyemmiter.js
@@ -8,7 +8,7 @@ const isEventValid = (event) => {
 };
 
 const getOrCreateEventSubscribersFor = (allEventSubscribers, event) => 
-  getEventSubscribersFor(event) ? getEventSubscribersFor(event) : createEventSubscribersFor(event);
+getEventSubscribersFor(allEventSubscribers, event) ? getEventSubscribersFor(allEventSubscribers, event) : createEventSubscribersFor(allEventSubscribers, event);
 
 const getEventSubscribersFor = (allEventSubscribers, event) => allEventSubscribers[event];
 
@@ -32,7 +32,7 @@ const unsubscribeCallback = (allEventSubscribers, event, callbackToRemove) => {
 
 const signalSubscribers = (eventSubscribers, ...args) => {
   const callbacksToUnsubscribeAfterCalled = [];
-  eventSubscribers.each((callback) => {
+  eventSubscribers.forEach((callback) => {
     callback.apply(callback.context, [...args]);
     if (callback.off_event) {
       callbacksToUnsubscribeAfterCalled.push(callback);
@@ -47,10 +47,10 @@ export class Emitter {
   emit(event, ...args) {
     const allEventSubscribers = this;
     if (isEventValid(event)) {
-      const eventSubscribers = getEventSubscribersFor(event);
+      const eventSubscribers = getEventSubscribersFor(allEventSubscribers, event);
       if (eventSubscribers) {
-        const callbacksToUnsubscribe = signalSubscribers(eventSubscribers, [...args]);
-        callbacksToUnsubscribe.each((callback) => {
+        const callbacksToUnsubscribe = signalSubscribers(eventSubscribers, ...args);
+        callbacksToUnsubscribe.forEach((callback) => {
           unsubscribeCallback(allEventSubscribers, event, callback);
         });
       }
@@ -80,7 +80,7 @@ export class Emitter {
   off(event, callback) {
     const allEventSubscribers = this;
     if (isEventValid(event)) {
-      const eventSubscribers = getEventSubscribersFor(event);
+      const eventSubscribers = getEventSubscribersFor(allEventSubscribers, event);
       if (eventSubscribers) {
         unsubscribeCallback(allEventSubscribers, event, callback);
       }
@@ -89,6 +89,7 @@ export class Emitter {
   }
 
   _e(e) {
-    return getOrCreateEventSubscribersFor(e);
+    const allEventSubscribers = this;
+    return getOrCreateEventSubscribersFor(allEventSubscribers, e);
   }
 }


### PR DESCRIPTION
Refactored code to make it easier to read from a higher level of abstraction. 

The interface has been kept the same as before. The callbacks subscribed are being stored also in the same way as before. Thus, the 'this' object has one list of callbacks for each event defined. However, since I found that using 'this' like that made the code a bit harder to read, I have been using an auxiliary variable instead to provide more semantic meaning (i.e. every 'public' method starts with something like 'const allEventSubscribers = this').

I have followed this approach because the 'this' object itself is returned in each method, and I wanted to keep the interface untouched. However, if we do not need to keep said interface, I think it would be clearer if we define a constructor with a 'this.allEventSubscribers' property.