### PR TITLE
#14 Add linter support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,15 @@
+# http://editorconfig.org
 root = true
 
-# All files
 [*]
+charset = utf-8
 end_of_line = crlf
 insert_final_newline = true
 indent_size = 2
 indent_style = space
-charset = utf-8
 trim_trailing_whitespace = true
+max_line_length = 120
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ insert_final_newline = true
 indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true
-max_line_length = 120
+max_line_length = 100
 
 [*.md]
 max_line_length = 0

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "prettier"
+  ],
+  "plugins": [
+    "react",
+    "jest"
+  ],
+  "env": {
+    "browser": true,
+    "node": true,
+    "jest/globals": true
+  },
+  "rules": {
+    "jest/no-disabled-tests": "warn"
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": true,
+  "arrowParens": "avoid",
+  "proseWrap": "never"
+}

--- a/package.json
+++ b/package.json
@@ -39,14 +39,15 @@
   },
   "scripts": {
     "clean": "rimraf lib dist es",
-    "prepublish": "npm run clean && npm run build",
+    "prepublish": "npm run clean && npm run prettier && npm run build",
     "build": "npm run clean && npm run build:commonjs && npm run build:umd && npm run build:umd:min && npm run build:es",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --copy-files --ignore spec.js,test.js",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --copy-files --ignore spec.js,test.js",
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack",
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack -p",
     "test": "cross-env NODE_ENV=test jest",
-    "test:watch": "cross-env NODE_ENV=test jest --watchAll"
+    "test:watch": "cross-env NODE_ENV=test jest --watchAll",
+    "prettier": "prettier --write \"src/**/*.{js, ts}\""
   },
   "dependencies": {
     "react": "^16.0.0"
@@ -63,6 +64,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.2.2",
     "jest": "^21.2.1",
+    "prettier": "1.9.2",
     "react-dom": "^16.1.1",
     "react-test-renderer": "^16.1.1",
     "regenerator-runtime": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -39,15 +39,16 @@
   },
   "scripts": {
     "clean": "rimraf lib dist es",
-    "prepublish": "npm run clean && npm run prettier && npm run build",
+    "prettier": "prettier --write \"{src,test}/**/*.{js, ts}\"",
+    "lint": "eslint \"{src,test}/**/*.js\"",
+    "prepublish": "npm run clean && npm run prettier && npm run lint && npm run test && npm run build",
     "build": "npm run clean && npm run build:commonjs && npm run build:umd && npm run build:umd:min && npm run build:es",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --copy-files --ignore spec.js,test.js",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --copy-files --ignore spec.js,test.js",
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack",
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack -p",
     "test": "cross-env NODE_ENV=test jest",
-    "test:watch": "cross-env NODE_ENV=test jest --watchAll",
-    "prettier": "prettier --write \"src/**/*.{js, ts}\""
+    "test:watch": "cross-env NODE_ENV=test jest --watchAll"
   },
   "dependencies": {
     "react": "^16.0.0"
@@ -63,6 +64,10 @@
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.2.2",
+    "eslint": "^4.15.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-jest": "^21.5.0",
+    "eslint-plugin-react": "^7.5.1",
     "jest": "^21.2.1",
     "prettier": "1.9.2",
     "react-dom": "^16.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export { trackPromise } from './trackPromise';
-export { promiseTrackerHoc } from './trackerHoc';
+export { trackPromise } from "./trackPromise";
+export { promiseTrackerHoc } from "./trackerHoc";

--- a/src/tinyEmmiter.js
+++ b/src/tinyEmmiter.js
@@ -1,4 +1,3 @@
-
 // Based on:
 // https://github.com/scottcorgan/tiny-emitter
 // class based
@@ -31,7 +30,7 @@ export class Emitter {
       delete this[event];
       return this;
     }
-    this[event] = e.filter((f) => f != fn);
+    this[event] = e.filter(f => f != fn);
     return this;
   }
   _e(e) {

--- a/src/trackPromise.js
+++ b/src/trackPromise.js
@@ -1,30 +1,26 @@
-import { Emitter } from './tinyEmmiter';
+import { Emitter } from "./tinyEmmiter";
 
 export const emitter = new Emitter();
-export const promiseCounterUpdateEventId = 'promise-counter-update';
+export const promiseCounterUpdateEventId = "promise-counter-update";
 
 let counter = 0;
 
 // TODO: Add unit test support
-export const trackPromise = (promise) => {
+export const trackPromise = promise => {
   counter++;
   const promiseInProgress = anyPromiseInProgress();
   emitter.emit(promiseCounterUpdateEventId, promiseInProgress);
 
-  promise
-    .then(() =>
-        decrementPromiseCounter())
-    .catch(() => {
-      decrementPromiseCounter();
-    });
+  promise.then(() => decrementPromiseCounter()).catch(() => {
+    decrementPromiseCounter();
+  });
 
   return promise;
 };
 
-const anyPromiseInProgress = () => (counter > 0);
+const anyPromiseInProgress = () => counter > 0;
 
 const decrementPromiseCounter = () => {
-
   counter--;
   const promiseInProgress = anyPromiseInProgress();
   emitter.emit(promiseCounterUpdateEventId, promiseInProgress);

--- a/src/trackPromise.test.js
+++ b/src/trackPromise.test.js
@@ -1,15 +1,13 @@
-import {trackPromise, emitter} from './trackPromise';
-import {Emitter} from './tinyEmmiter';
+import { trackPromise, emitter } from "./trackPromise";
 
-
-describe('trackPromise', () => {
-  test('On Initial case, promise fired, promise emitter.emit is called', () => {
+describe("trackPromise", () => {
+  test("On Initial case, promise fired, promise emitter.emit is called", () => {
     // Arrange
-    emitter.emit = jest.fn((a,b) => {
+    emitter.emit = jest.fn(() => {
       return;
     });
 
-    const myPromise =  Promise.resolve().then(() => {
+    const myPromise = Promise.resolve().then(() => {
       return "ok";
     });
 
@@ -22,13 +20,13 @@ describe('trackPromise', () => {
     return myPromise;
   });
 
-  test('Promise tracked, we got resolve, check that emit is called 2 times', () => {
+  test("Promise tracked, we got resolve, check that emit is called 2 times", () => {
     // Arrange
-    emitter.emit = jest.fn((a,b) => {
+    emitter.emit = jest.fn(() => {
       return;
     });
 
-    const myPromise =  Promise.resolve();
+    const myPromise = Promise.resolve();
 
     // Act
     trackPromise(myPromise);
@@ -39,37 +37,36 @@ describe('trackPromise', () => {
     });
   });
 
-  test.skip('Promise tracked, we got fail, check that emit is called 2 times', () => {
+  test.skip("Promise tracked, we got fail, check that emit is called 2 times", () => {
     // Arrange
     expect.assertions(1);
 
-    emitter.emit = jest.fn((a,b) => {
+    emitter.emit = jest.fn(() => {
       return;
     });
 
-    const myPromise =  Promise.reject();
+    const myPromise = Promise.reject();
 
     // Act
     trackPromise(myPromise);
 
     // Assert
-    return myPromise.catch(()=> {
-        expect(emitter.emit).toHaveBeenCalledTimes(2)
+    return myPromise.catch(() => {
+      expect(emitter.emit).toHaveBeenCalledTimes(2);
     });
   });
 
-
   // Pending promise failed
-  test('Two Promises tracked, we got resolve on both, check that emit is called 4 times', () => {
+  test("Two Promises tracked, we got resolve on both, check that emit is called 4 times", () => {
     // Arrange
     expect.assertions(1);
 
-    emitter.emit = jest.fn((a,b) => {
+    emitter.emit = jest.fn(() => {
       return;
     });
 
-    const myPromiseA =  Promise.resolve();
-    const myPromiseB =  Promise.resolve();
+    const myPromiseA = Promise.resolve();
+    const myPromiseB = Promise.resolve();
     const promises = [myPromiseA, myPromiseB];
 
     // Act
@@ -82,4 +79,3 @@ describe('trackPromise', () => {
     });
   });
 });
-

--- a/src/trackerHoc.js
+++ b/src/trackerHoc.js
@@ -1,17 +1,17 @@
-import React, { Component, PropTypes } from 'react'
-import { emitter, promiseCounterUpdateEventId } from './trackPromise';
+import React, { Component } from "react";
+import { emitter, promiseCounterUpdateEventId } from "./trackPromise";
 
-export const promiseTrackerHoc = (ComponentToWrap) => {
+export const promiseTrackerHoc = ComponentToWrap => {
   return class promiseTrackerComponent extends Component {
     constructor(props) {
       super(props);
 
-      this.state = {trackedPromiseInProgress: false};
+      this.state = { trackedPromiseInProgress: false };
     }
 
     componentWillMount() {
-      emitter.on(promiseCounterUpdateEventId, (anyPromiseInProgress) => {
-        this.setState({trackedPromiseInProgress: anyPromiseInProgress});
+      emitter.on(promiseCounterUpdateEventId, anyPromiseInProgress => {
+        this.setState({ trackedPromiseInProgress: anyPromiseInProgress });
       });
     }
 
@@ -21,8 +21,11 @@ export const promiseTrackerHoc = (ComponentToWrap) => {
 
     render() {
       return (
-        <ComponentToWrap {...this.props} trackedPromiseInProgress={this.state.trackedPromiseInProgress} />
-      )
+        <ComponentToWrap
+          {...this.props}
+          trackedPromiseInProgress={this.state.trackedPromiseInProgress}
+        />
+      );
     }
-  }
-}
+  };
+};

--- a/src/trackerHoc.test.js
+++ b/src/trackerHoc.test.js
@@ -1,29 +1,30 @@
-import React, { Component, PropTypes } from 'react';
-import { promiseTrackerHoc } from './trackerHoc'
+import React from "react";
+import { promiseTrackerHoc } from "./trackerHoc";
 
-describe('trackerHoc', () => {
+/* global mount */
 
-  test('Property trackedPromiseInProgress is passed down and value false', () => {
-    const DummyComponent = (props) => <span>test</span>;
+describe("trackerHoc", () => {
+  test("Property trackedPromiseInProgress is passed down and value false", () => {
+    const DummyComponent = () => <span>test</span>;
 
     const TrackedComponent = promiseTrackerHoc(DummyComponent);
-    const wrapper = mount(<TrackedComponent/>);
+    const wrapper = mount(<TrackedComponent />);
 
-    const dummyChild = wrapper.find('DummyComponent');
+    const dummyChild = wrapper.find("DummyComponent");
 
     expect(dummyChild).not.toBe(null);
-    expect(dummyChild.prop('trackedPromiseInProgress')).toBe(false);
+    expect(dummyChild.prop("trackedPromiseInProgress")).toBe(false);
   });
 
-  test('Additional properties are passed down to the child component', () => {
-    const DummyComponent = (props) => <span>test</span>;
+  test("Additional properties are passed down to the child component", () => {
+    const DummyComponent = () => <span>test</span>;
 
     const TrackedComponent = promiseTrackerHoc(DummyComponent);
-    const wrapper = mount(<TrackedComponent customprop='test'/>);
+    const wrapper = mount(<TrackedComponent customprop="test" />);
 
-    const dummyChild = wrapper.find('DummyComponent');
+    const dummyChild = wrapper.find("DummyComponent");
 
     expect(dummyChild).not.toBe(null);
-    expect(dummyChild.prop('customprop')).toBe('test');
+    expect(dummyChild.prop("customprop")).toBe("test");
   });
 });

--- a/test/jestsetup.js
+++ b/test/jestsetup.js
@@ -1,5 +1,5 @@
-import Enzyme, { shallow, render, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Enzyme, { shallow, render, mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
 
 // React 16 Enzyme adapter
 Enzyme.configure({ adapter: new Adapter() });
@@ -8,4 +8,3 @@ Enzyme.configure({ adapter: new Adapter() });
 global.shallow = shallow;
 global.render = render;
 global.mount = mount;
-

--- a/test/shim.js
+++ b/test/shim.js
@@ -1,4 +1,4 @@
 // https://github.com/facebook/jest/issues/4545#issuecomment-332762365
-global.requestAnimationFrame = (callback) => {
+global.requestAnimationFrame = callback => {
   setTimeout(callback, 0);
 };


### PR DESCRIPTION
- Added `prettier` as formatter. We can add a pre-commit hook to auto format everything, but I prefer to do it manually so far.
- Added `eslint` as JS linter. It has been configured with basic/recommended rules and integrated with `prettier` to avoid rule collision.
- Source code refactored to fulfill all the previous rules.