### PR TITLE
useEffect API accepts an array of values, not an object (config)

### DIFF
--- a/src/trackerHook.js
+++ b/src/trackerHook.js
@@ -18,7 +18,7 @@ export const usePromiseTracker = (outerConfig = defaultConfig) => {
       setInternalPromiseInProgress(true);
       setPromiseInProgress(true);
     }
-  }, config)
+  }, [config])
 
   // Internal will hold the current value
   const [


### PR DESCRIPTION
Hello,

I recently began receiving an error related to your hooks implementation (it may have coincided with the React 16.9 update):

```
Warning: useEffect received a final argument that is not an array (instead, received `object`). When specified, the final argument must be an array.
```

https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect

I thought I would submit a PR to fix, all tests passed (with a bit of noise about not being wrapped in `act(...)`).

Keep up the good work!

Cheers
