### PR TITLE
Fix mem leak warning on unmounted component

### DIFF
--- a/src/trackerHook.js
+++ b/src/trackerHook.js
@@ -56,7 +56,7 @@ export const usePromiseTracker = (outerConfig = defaultConfig) => {
       ? setPromiseInProgress(true)
       : setTimeout(() => {
           // Check here ref to internalPromiseInProgress
-          if (latestInternalPromiseInProgress.current) {
+          if (isMounted.current && latestInternalPromiseInProgress.current) {
             setPromiseInProgress(true);
           }
         }, config.delay);


### PR DESCRIPTION
Hi,
I found a issue about warning "Can't perform a React state update on an unmounted component." when removing the component which was using usePromiseTracker from DOM before it could finish updating its state.

For that reason i noticed that a check on isMounted.current was missing in notifyPromiseInProgress function.

Greets